### PR TITLE
Set guava version to fit Hadoop requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 
         <dbSetup.version>2.1.0</dbSetup.version>
         <httpclient.version>4.4.1</httpclient.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>11.0.2</guava.version>
         <concurrentlinkedhashmap-lru.version>1.4</concurrentlinkedhashmap-lru.version>
         <jetty-util.version>9.3.21.v20170918</jetty-util.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>


### PR DESCRIPTION
Hadoop is using an old version of Guava lib (11.0.2), using a more recent version of Guava lib will cause a NoSuchMethodError on ComparisonChain.compare(boolean, boolean) that have changed on Guava 12.0.